### PR TITLE
Feature/prevenir compra sin cupo

### DIFF
--- a/app/templates/app/ticket_compra.html
+++ b/app/templates/app/ticket_compra.html
@@ -62,6 +62,13 @@
                         Acepto los <a href="#" class="text-primary">términos y condiciones</a> y la <a href="#" class="text-primary">política de privacidad</a>
                     </label>
                 </div>
+
+                <!-- condicion que si hay error se muestre   -->
+                {% if error %}
+                    <div class="alert alert-danger" role="alert">
+                        {{ error }}
+                    </div>
+                {% endif %}
                 
                 <button type="submit" class="btn btn-primary w-100" id="submit-btn">Confirmar compra</button>
             </form>

--- a/app/test/test_integration/test_ticket.py
+++ b/app/test/test_integration/test_ticket.py
@@ -102,3 +102,36 @@ class PruebaTicketInt(CompraTicketLimiteTest):
 
         total_tickets = Ticket.objects.filter(user=self.user, event=self.event).aggregate(total=Sum('quantity'))['total']
         self.assertEqual(total_tickets, 3)  # No aumentó
+
+
+    #Agrego test para validar que no se pueda comprar mas entradas de la cantidad de entradas disponibles
+    def test_no_puede_comprar_mas_de_entradas_disponibles(self):
+        # Crea un evento con 3 entradas disponibles
+        event = Event.objects.create(
+            title="Evento test",
+            description="Descripción de prueba",
+            scheduled_at=timezone.now() + datetime.timedelta(days=1),
+            organizer=self.organizer,
+            capacity=3
+        )
+
+        # Crea un ticket con 3 entradas
+        Ticket.objects.create(
+            ticket_code="CODE123",
+            quantity=3,
+            user=self.user,
+            event=event
+        )
+
+        # Intenta comprar 1 entrada más
+        post_data = {
+            "quantity": 1,
+            "ticket_code": "CODE456",
+            "type": "general",
+            **self._get_payment_data()
+        }
+        response = self.client.post(self.ticket_url, post_data)
+        self.assertEqual(response.status_code, 200)  # No redirige porque excede límite
+
+        total_tickets = Ticket.objects.filter(user=self.user, event=event).aggregate(total=Sum('quantity'))['total']
+        self.assertEqual(total_tickets, 3) 

--- a/app/views.py
+++ b/app/views.py
@@ -540,9 +540,23 @@ def comprar_ticket(request, event_id):
                 'event': event,
                 'event_id': event_id
             })
+        
+        # verificar si hay cupo, si no hay cupo se muestra un error que diga no quedan entradas
+        if event.capacity is not None:
+            tickets_vendidos = Ticket.objects.filter(event=event).aggregate(total=Sum('quantity'))['total'] or 0
+            if tickets_vendidos + quantity > event.capacity:
+                # mostrar cantidad de entradas disponibles
+                tickets_disponibles = event.capacity - tickets_vendidos
+                if tickets_disponibles == 0:
+                    error = "No quedan entradas disponibles."
+                else:
+                    error = f"No quedan entradas disponibles. Solo quedan {tickets_disponibles} entradas."
 
-
-
+                return render(request, 'app/ticket_compra.html', {
+                    'event': event,
+                    'event_id': event_id,
+                    'error': error
+                })
         # Datos de pago (estos se enviarían a una API externa en un caso real)
         payment_data = {
             'card_number': request.POST.get('card_number'),


### PR DESCRIPTION
Se agregó la validación para evitar la compra de entradas cuando el cupo del evento está agotado o casi agotado.
Al enviar el formulario de compra, el usuario recibe un mensaje dinámico en un cartel rojo que indica si no quedan entradas disponibles o cuántas quedan exactamente.
Esta funcionalidad mejora la experiencia de compra y previene intentos fallidos.
Además, se agregaron pruebas unitarias, de integración y end-to-end para garantizar el correcto comportamiento.

Closes #8