### PR TITLE
Feature/ocultar eventos pasados

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -56,6 +56,10 @@ class Event(models.Model):
         if self.scheduled_at > now and self.status not in ["Cancelado", "Finalizado"]:
             return self.scheduled_at - now
         return None
+    
+    @property
+    def es_pasado(self):
+        return self.scheduled_at < timezone.now()
 
     def is_organizer(self, user):
         return self.organizer == user

--- a/app/templates/app/events.html
+++ b/app/templates/app/events.html
@@ -52,6 +52,14 @@
                 </div>
             </div>
         {% endif %}
+        {% if user_is_organizer %}
+            <div class="form-check mt-4">
+                <input class="form-check-input" type="checkbox" name="ver_pasados" id="ver_pasados" {% if ver_pasados %}checked{% endif %}>
+                <label class="form-check-label" for="ver_pasados">
+                    Ver eventos pasados
+                </label>
+            </div>
+        {% endif %}
     </form>
 
     <table class="table">

--- a/app/test/test_e2e/test_events.py
+++ b/app/test/test_e2e/test_events.py
@@ -290,6 +290,26 @@ class EventPermissionsTest(EventBaseTest):
         countdown = self.page.locator("#countdown")
         expect(countdown).to_have_count(0)
 
+    def test_filter_past_events_visible_only_for_organizer(self):
+        """Test que verifica que el filtro de eventos pasados solo es visible para organizadores"""
+
+    # Iniciar sesión como organizador
+        self.login_user("organizador", "password123")
+        self.page.goto(f"{self.live_server_url}/events/")
+
+    # Verificar que el checkbox 'Ver eventos pasados' es visible
+        past_events_checkbox = self.page.get_by_label("Ver eventos pasados")
+        expect(past_events_checkbox).to_be_visible()
+
+    # Cerrar sesión
+        self.page.get_by_role("button", name="Salir").click()
+
+    # Iniciar sesión como usuario regular
+        self.login_user("usuario", "password123")
+        self.page.goto(f"{self.live_server_url}/events/")
+
+    # Verificar que el checkbox 'Ver eventos pasados' no esté presente
+        past_events_checkbox = self.page.locator("label", has_text="Ver eventos pasados")
 
 class EventCRUDTest(EventBaseTest):
     """Tests relacionados con las operaciones CRUD (Crear, Leer, Actualizar, Eliminar) de eventos"""

--- a/app/test/test_integration/test_event.py
+++ b/app/test/test_integration/test_event.py
@@ -93,6 +93,26 @@ class EventsListViewTest(BaseEventTestCase):
         # Verificar que redirecciona al login
         self.assertEqual(response.status_code, 302)
         self.assertTrue(response['Location'].startswith("/accounts/login/"))
+    
+    def test_events_view_excludes_past_events(self):
+        """Test que verifica que la vista events no muestra eventos pasados"""
+        # Crear un evento pasado
+        past_event = Event.objects.create(
+            title="Evento Pasado",
+            description="Descripción del evento pasado",
+            scheduled_at=timezone.now() - datetime.timedelta(days=1),
+            organizer=self.organizer,
+        )
+
+        # Login con usuario regular
+        self.client.login(username="regular", password="password123")
+
+        # Hacer petición a la vista events
+        response = self.client.get(reverse("events"))
+
+        # Verificar respuesta
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn(past_event, response.context["events"])
 
 
 class EventDetailViewTest(BaseEventTestCase):

--- a/app/test/test_unit/test_event.py
+++ b/app/test/test_unit/test_event.py
@@ -175,3 +175,12 @@ class EventModelTest(TestCase):
         event.save()
         self.assertIsInstance(event.countdown, datetime.timedelta)
 
+    def test_event_es_pasado_con_fecha_pasada(self):
+        """Test que verifica que si tengo un evento pasado el metodo es_pasado devuelve True"""
+        event = Event.objects.create(
+            title="Evento pasado",
+            description="Descripción del evento pasado",
+            scheduled_at=timezone.now() - datetime.timedelta(days=1),
+            organizer=self.organizer,
+        )
+        self.assertTrue(event.es_pasado)

--- a/app/views.py
+++ b/app/views.py
@@ -188,9 +188,13 @@ def events(request):
     category_id = request.GET.get("category")
     venue_id = request.GET.get("venue")
     favorites_only = request.GET.get("favorites_only") == "on"
-
+    ver_pasados = request.GET.get("ver_pasados") == "on"
+    
+    
     if user.is_organizer:
         events = Event.objects.filter(organizer=user)
+        if not ver_pasados:
+            events = events.filter(scheduled_at__gte=timezone.now()).exclude(status__in=["Cancelado", "Finalizado"])
     else:
         events = Event.objects.filter(scheduled_at__gte=timezone.now()).exclude(status__in=["Cancelado", "Finalizado"])
 
@@ -231,6 +235,7 @@ def events(request):
             "order": order,
             "user_is_organizer": user.is_organizer,
             "favorites_only": favorites_only,
+            "ver_pasados": ver_pasados,
         },
     )
 


### PR DESCRIPTION
Oculto eventos pasados del dashboard por defecto.
Se modificó la vista `events` para aplicar el filtrado condicional.
- Se agregó un checkbox en `events.html`, visible solo para organizadores.
- Se agregaron tests:
  -  Unitarios
  - De integración 
  - End-to-End
