### PR TITLE
Se valida que al editar, el evento no este cancelado o finalizado

### DIFF
--- a/app/views.py
+++ b/app/views.py
@@ -751,6 +751,11 @@ def update_ticket(request, ticket_id):
     if RefoundRequest.objects.filter(ticket_code=ticket.ticket_code).exists():
         messages.error(request, "No se puede editar un ticket que tiene una solicitud de reembolso.")
         return redirect('Mis_tickets')
+    
+    #si el evento al que esta asociado el ticket tiene estado finalizado / cancelado, no se puede editar
+    if ticket.event.status in ['Finalizado', 'Cancelado']:
+        messages.error(request, "No se puede editar un ticket de un evento que ya no esta disponible.")
+        return redirect('Mis_tickets')
 
     if request.method == 'POST':
         quantity = request.POST.get('quantity')


### PR DESCRIPTION
Se soluciona bug que permitia que se pueda editar un ticket de un evento que tiene un estado cancelado/finalizado.