### PR TITLE
Se agrega pipeline de notificacion cuando se mergea a main

### DIFF
--- a/.github/workflows/telegram-notify.yml
+++ b/.github/workflows/telegram-notify.yml
@@ -1,0 +1,21 @@
+name: Notificar por Telegram cuando se mergea a main
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+jobs:
+  notify:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enviar mensaje por Telegram
+        env:
+          TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+        run: |
+          curl -s -X POST https://api.telegram.org/bot$TELEGRAM_TOKEN/sendMessage \
+            -d chat_id=$TELEGRAM_CHAT_ID \
+            -d text=" Se hizo *merge* del PR '${{ github.event.pull_request.title }}' a *main* por *${{ github.actor }}*." \
+            -d parse_mode=Markdown


### PR DESCRIPTION
Este PR introduce un nuevo workflow de GitHub Actions que envía un mensaje a Telegram cuando se hace merge a la rama main.

Para mantener informado al equipo de los merges a producción, automatizando la comunicación mediante un bot de Telegram.